### PR TITLE
Replace ask_y_n() with ask_yes_no().

### DIFF
--- a/Changes
+++ b/Changes
@@ -27,6 +27,11 @@ Revision history for Perl extension App::Sqitch
        `sqitch-authentication`, as well as `$SNOWSQL_PRIVATE_KEY_PASSPHRASE`
        in `sqitch-environment`. Thanks to Casey Largent for figuring it out
        (#441).
+     - Added the `ask_yes_no()` method as a reaplcement for `ask_y_n()`, which
+       is now deprecated. The new method expects localized responses from the
+       user when translations are provided. Defaults to the English "yes" and
+       "no" when no translation is available. Suggested by German translator
+       Thomas Iguchi (#449).
 
 0.9999 2019-02-01T15:29:40Z
      [Bug Fixes]

--- a/lib/App/Sqitch/Engine.pm
+++ b/lib/App/Sqitch/Engine.pm
@@ -300,11 +300,11 @@ sub revert {
                 ident   => 'revert:confirm',
                 message => __ 'Nothing reverted',
                 exitval => 1,
-            } unless $sqitch->ask_y_n(__x(
+            } unless $sqitch->ask_yes_no(__x(
                 'Revert changes to {change} from {destination}?',
                 change      => $change->format_name_with_tags,
                 destination => $self->destination,
-            ), $self->prompt_accept ? 'Yes' : 'No' );
+            ), $self->prompt_accept );
         }
 
     } else {
@@ -323,10 +323,10 @@ sub revert {
                 ident   => 'revert',
                 message => __ 'Nothing reverted',
                 exitval => 1,
-            } unless $sqitch->ask_y_n(__x(
+            } unless $sqitch->ask_yes_no(__x(
                 'Revert all changes from {destination}?',
                 destination => $self->destination,
-            ), $self->prompt_accept ? 'Yes' : 'No' );
+            ), $self->prompt_accept );
         }
     }
 

--- a/po/App-Sqitch.pot
+++ b/po/App-Sqitch.pot
@@ -43,6 +43,16 @@ msgid ""
 "Sqitch seems to be unattended and there is no default value for this question"
 msgstr ""
 
+#: lib/App/Sqitch.pm:428
+msgctxt "Confirm prompt answer yes"
+msgid "Yes"
+msgstr ""
+
+#: lib/App/Sqitch.pm:429
+msgctxt "Confirm prompt answer no"
+msgid "No"
+msgstr ""
+
 #: lib/App/Sqitch.pm:438
 msgid "Please answer \"y\" or \"n\"."
 msgstr ""

--- a/t/base.t
+++ b/t/base.t
@@ -2,7 +2,7 @@
 
 use strict;
 use warnings;
-use Test::More tests => 158;
+use Test::More tests => 189;
 #use Test::More 'no_plan';
 use Test::MockModule 0.17;
 use Path::Class;
@@ -28,6 +28,7 @@ can_ok $CLASS, qw(
     user_email
     verbosity
     prompt
+    ask_yes_no
     ask_y_n
 );
 
@@ -536,12 +537,69 @@ is capture_stdout {
 }, "hi [yo] yo\n", 'Prompt should show default as selected when unattended';
 
 ##############################################################################
+# Test ask_yes_no().
+throws_ok { $sqitch->ask_yes_no } 'App::Sqitch::X',
+    'Should get error for no ask_yes_no message';
+is $@->ident, 'DEV', 'No ask_yes_no ident should be "DEV"';
+is $@->message, 'ask_yes_no() called without a prompt message',
+    'No ask_yes_no error message should be correct';
+
+my $yes = __ 'Yes';
+my $no = __ 'No';
+
+# Test affermation.
+for my $variant ($yes, lc $yes, uc $yes, lc substr($yes, 0, 1), substr($yes, 0, 2)) {
+    $input = $variant;
+    $unattended = 0;
+    is capture_stdout {
+        ok $sqitch->ask_yes_no('hi'),
+            qq{ask_yes_no() should return true for "$variant" input};
+    }, 'hi ', qq{ask_yes_no() should prompt for "$variant"};
+}
+
+# Test negation.
+for my $variant ($no, lc $no, uc $no, lc substr($no, 0, 1), substr($no, 0, 2)) {
+    $input = $variant;
+    $unattended = 0;
+    is capture_stdout {
+        ok !$sqitch->ask_yes_no('hi'),
+            qq{ask_yes_no() should return false for "$variant" input};
+    }, 'hi ', qq{ask_yes_no() should prompt for "$variant"};
+}
+
+# Test defaults.
+$input = '';
+is capture_stdout {
+    ok $sqitch->ask_yes_no('whu?', 1),
+        'ask_yes_no() should return true for true default'
+}, "whu? [$yes] ", 'ask_yes_no() should prompt and show default "Yes"';
+is capture_stdout {
+    ok !$sqitch->ask_yes_no('whu?', 0),
+        'ask_yes_no() should return false for false default'
+}, "whu? [$no] ", 'ask_yes_no() should prompt and show default "No"';
+
+my $please = __ 'Please answer "y" or "n".';
+$input = 'ha!';
+throws_ok {
+    is capture_stdout { $sqitch->ask_yes_no('hi')  },
+        "hi  \n$please\nhi  \n$please\nhi  \n",
+         'Should get prompts for repeated bad answers';
+} 'App::Sqitch::X', 'Should get error for bad answers';
+is $@->ident, 'io', 'Bad answers ident should be "IO"';
+is $@->message, __ 'No valid answer after 3 attempts; aborting',
+    'Bad answers message should be correct';
+
+##############################################################################
 # Test ask_y_n().
+my $warning;
+$sqitch_mock->mock(warn => sub { shift; $warning = "@_" });
 throws_ok { $sqitch->ask_y_n } 'App::Sqitch::X',
     'Should get error for no ask_y_n message';
 is $@->ident, 'DEV', 'No ask_y_n ident should be "DEV"';
-is $@->message, 'ask_y_n() called without a prompt message',
+is $@->message, 'ask_yes_no() called without a prompt message',
     'No ask_y_n error message should be correct';
+is $warning, 'The ask_y_n() method has been deprecated. Use ask_yes_no() instead.',
+    'Should get a deprecation warning from ask_y_n';
 
 throws_ok { $sqitch->ask_y_n('hi', 'b') } 'App::Sqitch::X',
     'Should get error for invalid ask_y_n default';
@@ -549,36 +607,42 @@ is $@->ident, 'DEV', 'Invalid ask_y_n default ident should be "DEV"';
 is $@->message, 'Invalid default value: ask_y_n() default must be "y" or "n"',
     'Invalid ask_y_n default error message should be correct';
 
-$input = 'y';
+$input = lc substr $yes, 0, 1;
 $unattended = 0;
 is capture_stdout {
-    ok $sqitch->ask_y_n('hi'), 'ask_y_n should return true for "y" input';
+    ok $sqitch->ask_y_n('hi'),
+        qq{ask_y_n should return true for "$input" input}
 }, 'hi ', 'ask_y_n() should prompt';
 
-$input = 'no';
+$input = lc substr $no, 0, 1;
 is capture_stdout {
-    ok !$sqitch->ask_y_n('howdy'), 'ask_y_n should return false for "no" input';
+    ok !$sqitch->ask_y_n('howdy'),
+        qq{ask_y_n should return false for "$input" input}
 }, 'howdy ', 'ask_y_n() should prompt for no';
 
-$input = 'Nein';
+$input = uc substr $no, 0, 1;
 is capture_stdout {
-    ok !$sqitch->ask_y_n('howdy'), 'ask_y_n should return false for "Nein"';
+    ok !$sqitch->ask_y_n('howdy'),
+        qq{ask_y_n should return false for "$input" input}
 }, 'howdy ', 'ask_y_n() should prompt for no';
 
-$input = 'Yep';
+$input = uc substr $yes, 0, 2;
 is capture_stdout {
-    ok $sqitch->ask_y_n('howdy'), 'ask_y_n should return true for "Yep"';
+    ok $sqitch->ask_y_n('howdy'),
+        qq{ask_y_n should return true for "$input" input}
 }, 'howdy ', 'ask_y_n() should prompt for yes';
 
 $input = '';
 is capture_stdout {
-    ok $sqitch->ask_y_n('whu?', 'y'), 'ask_y_n should return true default "y"';
-}, 'whu? [y] ', 'ask_y_n() should prompt and show default "y"';
-is capture_stdout {
-    ok !$sqitch->ask_y_n('whu?', 'n'), 'ask_y_n should return false default "n"';
-}, 'whu? [n] ', 'ask_y_n() should prompt and show default "n"';
+    ok $sqitch->ask_y_n('whu?', 'y'),
+        qq{ask_y_n should return true default "$yes"}
+}, "whu? [$yes] ", 'ask_y_n() should prompt and show default "Yes"';
 
-my $please = __ 'Please answer "y" or "n".';
+is capture_stdout {
+    ok !$sqitch->ask_y_n('whu?', 'n'),
+        qq{ask_y_n should return false default "$no"};
+}, "whu? [$no] ", 'ask_y_n() should prompt and show default "No"';
+
 $input = 'ha!';
 throws_ok {
     is capture_stdout { $sqitch->ask_y_n('hi')  },

--- a/t/engine.t
+++ b/t/engine.t
@@ -1859,7 +1859,7 @@ my @dbchanges;
     $params;
 } @changes[0..3];
 
-MockOutput->ask_y_n_returns(1);
+MockOutput->ask_yes_no_returns(1);
 ok $engine->revert, 'Revert all changes';
 is_deeply $engine->seen, [
     [deployed_changes => undef],
@@ -1873,11 +1873,11 @@ is_deeply $engine->seen, [
     [run_file => $dbchanges[0]->revert_file ],
     [log_revert_change => $dbchanges[0] ],
 ], 'Should have reverted the changes in reverse order';
-is_deeply +MockOutput->get_ask_y_n, [
+is_deeply +MockOutput->get_ask_yes_no, [
     [__x(
         'Revert all changes from {destination}?',
         destination => $engine->destination,
-    ), 'Yes'],
+    ), 1],
 ], 'Should have prompted to revert all changes';
 is_deeply +MockOutput->get_info_literal, [
     ['  - lolz ..', '.........', ' '],
@@ -1904,11 +1904,11 @@ is_deeply $engine->seen, [
     [log_revert_change => $dbchanges[1] ],
     [log_revert_change => $dbchanges[0] ],
 ], 'Log-only Should have reverted the changes in reverse order';
-is_deeply +MockOutput->get_ask_y_n, [
+is_deeply +MockOutput->get_ask_yes_no, [
     [__x(
         'Revert all changes from {destination}?',
         destination => $engine->destination,
-    ), 'Yes'],
+    ), 1],
 ], 'Log-only should have prompted to revert all changes';
 is_deeply +MockOutput->get_info_literal, [
     ['  - lolz ..', '.........', ' '],
@@ -1924,7 +1924,7 @@ is_deeply +MockOutput->get_info, [
 ], 'And the revert successes should be emitted';
 
 # Should exit if the revert is declined.
-MockOutput->ask_y_n_returns(0);
+MockOutput->ask_yes_no_returns(0);
 throws_ok { $engine->revert } 'App::Sqitch::X', 'Should abort declined revert';
 is $@->ident, 'revert', 'Declined revert ident should be "revert"';
 is $@->exitval, 1, 'Should have exited with value 1';
@@ -1932,17 +1932,17 @@ is $@->message, __ 'Nothing reverted', 'Should have exited with proper message';
 is_deeply $engine->seen, [
     [deployed_changes => undef],
 ], 'Should have called deployed_changes only';
-is_deeply +MockOutput->get_ask_y_n, [
+is_deeply +MockOutput->get_ask_yes_no, [
     [__x(
         'Revert all changes from {destination}?',
         destination => $engine->destination,
-    ), 'Yes'],
+    ), 1],
 ], 'Should have prompt to revert all changes';
 is_deeply +MockOutput->get_info, [
 ], 'It should have emitted nothing else';
 
 # Revert all changes with no prompt.
-MockOutput->ask_y_n_returns(1);
+MockOutput->ask_yes_no_returns(1);
 $engine->log_only(0);
 $engine->no_prompt(1);
 ok $engine->revert, 'Revert all changes with no prompt';
@@ -1958,7 +1958,7 @@ is_deeply $engine->seen, [
     [run_file => $dbchanges[0]->revert_file ],
     [log_revert_change => $dbchanges[0] ],
 ], 'Should have reverted the changes in reverse order';
-is_deeply +MockOutput->get_ask_y_n, [], 'Should have no prompt';
+is_deeply +MockOutput->get_ask_yes_no, [], 'Should have no prompt';
 
 is_deeply +MockOutput->get_info_literal, [
     ['  - lolz ..', '.........', ' '],
@@ -1995,12 +1995,12 @@ is_deeply $engine->seen, [
     [run_file => $dbchanges[2]->revert_file ],
     [log_revert_change => $dbchanges[2] ],
 ], 'Should have reverted only changes after @alpha';
-is_deeply +MockOutput->get_ask_y_n, [
+is_deeply +MockOutput->get_ask_yes_no, [
     [__x(
         'Revert changes to {change} from {destination}?',
         destination => $engine->destination,
         change      => $dbchanges[1]->format_name_with_tags,
-    ), 'Yes'],
+    ), 1],
 ], 'Should have prompt to revert to change';
 is_deeply +MockOutput->get_info_literal, [
     ['  - lolz ..', '.........', ' '],
@@ -2011,7 +2011,7 @@ is_deeply +MockOutput->get_info, [
     [__ 'ok'],
 ], 'And the revert successes should be emitted';
 
-MockOutput->ask_y_n_returns(0);
+MockOutput->ask_yes_no_returns(0);
 $offset_change = $dbchanges[1];
 push @resolved => $offset_change->id;
 throws_ok { $engine->revert('@alpha') } 'App::Sqitch::X',
@@ -2024,18 +2024,18 @@ is_deeply $engine->seen, [
     [change_offset_from_id => [$dbchanges[1]->id, 0] ],
     [deployed_changes_since => $dbchanges[1]],
 ], 'Should have called revert methods';
-is_deeply +MockOutput->get_ask_y_n, [
+is_deeply +MockOutput->get_ask_yes_no, [
     [__x(
         'Revert changes to {change} from {destination}?',
         change      => $dbchanges[1]->format_name_with_tags,
         destination => $engine->destination,
-    ), 'Yes'],
+    ), 1],
 ], 'Should have prompt to revert to @alpha';
 is_deeply +MockOutput->get_info, [
 ], 'It should have emitted nothing else';
 
 # Try to revert just the last change with no prompt
-MockOutput->ask_y_n_returns(1);
+MockOutput->ask_yes_no_returns(1);
 $engine->no_prompt(1);
 my $rev_file = $dbchanges[-1]->revert_file; # Grab before deleting _rework_tags.
 my $rtags = delete $dbchanges[-1]->{_rework_tags}; # These need to be invisible.
@@ -2051,7 +2051,7 @@ is_deeply $engine->seen, [
     [run_file => $rev_file ],
     [log_revert_change => { %{ $dbchanges[-1] }, _rework_tags => $rtags } ],
 ], 'Should have reverted one changes for @HEAD^';
-is_deeply +MockOutput->get_ask_y_n, [], 'Should have no prompt';
+is_deeply +MockOutput->get_ask_yes_no, [], 'Should have no prompt';
 is_deeply +MockOutput->get_info_literal, [
     ['  - lolz ..', '', ' '],
 ], 'Output should show what it reverts to';

--- a/t/lib/MockOutput.pm
+++ b/t/lib/MockOutput.pm
@@ -26,14 +26,14 @@ my @mocked = qw(
     page
     page_literal
     prompt
-    ask_y_n
+    ask_yes_no
 );
 
 my $INPUT;
 sub prompt_returns { $INPUT = $_[1]; }
 
 my $Y_N;
-sub ask_y_n_returns { $Y_N = $_[1]; }
+sub ask_yes_no_returns { $Y_N = $_[1]; }
 
 my %CAPTURED;
 
@@ -61,9 +61,9 @@ $MOCK->mock(prompt => sub {
     return $INPUT;
 });
 
-$MOCK->mock(ask_y_n => sub {
+$MOCK->mock(ask_yes_no => sub {
     shift;
-    push @{ $CAPTURED{ask_y_n} } => [@_];
+    push @{ $CAPTURED{ask_yes_no} } => [@_];
     return $Y_N;
 });
 


### PR DESCRIPTION
The new version localizes the default value, and expects localized input from
the use, when a translation is available. Its second argument, when passed,
determines whether the default is affirmative (yes) or negative (no). The user
may input a substring of either answer, such as "y" for "Yes" or "j" for "Ja".
Translators therefore must be sure that the first char of each answer is
distinct, at least for now.

The ask_y_n() method is deprecated with a warning, and its use in Sqitch
itself replaced with calls to `ask_yes_no(). This change required changing the
way MockOutput handles mock prompts, as well.

Based on a suggestion by @tiguchi in #449.